### PR TITLE
Modify install composer task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     mode: 0755
 
 - name: install composer
-  command: "./installer"
+  command: "php installer"
   args:
     chdir: "{{ composer_install_dir }}"
     creates: "{{ composer_install_dir }}/composer.phar"


### PR DESCRIPTION
This was triggering an error as installer is a php script, not a shell script.